### PR TITLE
Present-weather types + logging hygiene (v5.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Notable changes to get-weather-data. Versions follow the git tags.
 
+## 5.2.0
+
+Added
+
+- Present-weather phenomena: `Weather(include_weather_types=True)`
+  populates `result.weather_types` (a set like `{"fog", "thunder"}`)
+  from GHCN `WT**` occurrence codes and GSOD's `FRSHTT` indicator, on
+  both the station and online backends.
+- `--weather-types` flag on `get-weather get` (shown in the table) and
+  `get-weather process` (adds a comma-joined `weather_types` CSV
+  column); `get_frame(...)` adds the column when the data carries it.
+
+Changed
+
+- Library hygiene: attach a `NullHandler` to the package logger so
+  importing get-weather-data never emits log output unless the host
+  application configures logging.
+
 ## 5.1.0
 
 Added

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Notes on online mode:
   dew point, pressures, and visibility
 - **Quality-controlled**: values that failed NOAA's QC are dropped by
   default; `include_flags=True` surfaces the per-field QC flag
+- **Present weather**: `include_weather_types=True` reports the day's
+  phenomena (fog, thunder, hail, freezing rain, ...) from GHCN `WT**`
+  codes and GSOD's `FRSHTT` indicator
 - **Automatic station selection**: nearest station first, farther
   stations fill in missing variables; `coverage(...)` reports how well
   a point is served
@@ -226,6 +229,25 @@ a genuine zero is reported as `0.0`.
 
 With `include_flags=True`, `result.flags` maps each field to its GHCN
 quality-control flag (blank = passed all checks; GHCN stations only).
+
+### Present-weather types
+
+The numeric variables above say how much rain fell but not whether it
+was *thunder*, *freezing rain*, or *fog*. With
+`include_weather_types=True`, `result.weather_types` is a set of the
+day's phenomena, drawn from GHCN `WT**` occurrence codes (fog, thunder,
+hail, glaze, blowing snow, ...) and, for GSOD airport stations, the
+`FRSHTT` indicator (fog / rain / snow / hail / thunder / tornado):
+
+```python
+w = Weather(online=True, include_weather_types=True)
+r = w.get("11430", "2023-07-16")   # JFK on a stormy afternoon
+print(sorted(r.weather_types))     # ['fog', 'heavy_fog', 'thunder']
+```
+
+`get-weather get <loc> <date> --weather-types` shows them on the CLI,
+and `process --weather-types` adds a comma-joined `weather_types`
+column to the batch CSV.
 
 ## Which backend?
 

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ hail, glaze, blowing snow, ...) and, for GSOD airport stations, the
 
 ```python
 w = Weather(online=True, include_weather_types=True)
-r = w.get("11430", "2023-07-16")   # JFK on a stormy afternoon
-print(sorted(r.weather_types))     # ['fog', 'heavy_fog', 'thunder']
+r = w.get("11430", "2023-07-16")  # JFK on a stormy afternoon
+print(sorted(r.weather_types))  # ['fog', 'heavy_fog', 'thunder']
 ```
 
 `get-weather get <loc> <date> --weather-types` shows them on the CLI,

--- a/src/get_weather_data/__init__.py
+++ b/src/get_weather_data/__init__.py
@@ -20,12 +20,17 @@ Basic usage:
     weather.process_csv("input.csv", "output.csv")
 """
 
+import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from get_weather_data.main import Weather
 from get_weather_data.weather.location import LocationInput
 from get_weather_data.weather.results import Coverage, WeatherResult
 from get_weather_data.weather.units import Units
+
+# Library hygiene: attach a NullHandler so importing the package never
+# emits log output unless the host application configures logging itself.
+logging.getLogger("get_weather_data").addHandler(logging.NullHandler())
 
 try:
     __version__ = version("get-weather-data")

--- a/src/get_weather_data/cli.py
+++ b/src/get_weather_data/cli.py
@@ -99,6 +99,11 @@ def setup(
     is_flag=True,
     help="Query the NOAA CDO API directly (no local database; requires NCDC_TOKEN)",
 )
+@click.option(
+    "--weather-types",
+    is_flag=True,
+    help="Also report present-weather phenomena (fog, thunder, hail, ...)",
+)
 @click.pass_context
 def get(
     ctx: click.Context,
@@ -108,6 +113,7 @@ def get(
     elements: str | None,
     source: str,
     online: bool,
+    weather_types: bool,
 ) -> None:
     """Get weather data for a location and date.
 
@@ -123,6 +129,7 @@ def get(
             online=online,
             units=units,  # type: ignore[arg-type]
             source=source,  # type: ignore[arg-type]
+            include_weather_types=weather_types,
         )
         element_list = elements.split(",") if elements else None
         result = weather.get(location, target_date, elements=element_list)
@@ -153,6 +160,13 @@ def get(
             f"{value:.1f} {label}" if value is not None else "N/A",
         )
 
+    if weather_types:
+        phenomena = result.weather_types
+        table.add_row(
+            "Weather Types",
+            ", ".join(sorted(phenomena)) if phenomena else "none",
+        )
+
     console.print(table)
 
 
@@ -172,6 +186,11 @@ def get(
 @click.option("--year-column", default="year", help="Year column name")
 @click.option("--month-column", default="month", help="Month column name")
 @click.option("--day-column", default="day", help="Day column name")
+@click.option(
+    "--weather-types",
+    is_flag=True,
+    help="Add a weather_types column with present-weather phenomena",
+)
 @click.option("--parallel/--no-parallel", default=True, help="Use parallel processing")
 @click.option("--workers", type=int, help="Number of worker threads (default: auto)")
 @click.pass_context
@@ -187,6 +206,7 @@ def process(
     year_column: str,
     month_column: str,
     day_column: str,
+    weather_types: bool,
     parallel: bool,
     workers: int | None,
 ) -> None:
@@ -202,6 +222,7 @@ def process(
         database_path=ctx.obj["database"],
         verbose=ctx.obj["verbose"],
         units=units,  # type: ignore[arg-type]
+        include_weather_types=weather_types,
     )
 
     mode = "parallel" if parallel else "sequential"

--- a/src/get_weather_data/main.py
+++ b/src/get_weather_data/main.py
@@ -62,6 +62,7 @@ class Weather:
     online: bool = False
     units: Units = "metric"
     include_flags: bool = False
+    include_weather_types: bool = False
     interpolate: bool = False
     source: Source = "station"
     _db: Database | None = field(default=None, repr=False)
@@ -83,7 +84,10 @@ class Weather:
 
         if self.online:
             # Fail fast on a missing token, and skip the local database
-            self._online_lookup = OnlineLookup(units=self.units)
+            self._online_lookup = OnlineLookup(
+                units=self.units,
+                include_weather_types=self.include_weather_types,
+            )
         else:
             self._db = Database(self.database_path)
 
@@ -102,6 +106,7 @@ class Weather:
                 db=self.db,
                 units=self.units,
                 include_flags=self.include_flags,
+                include_weather_types=self.include_weather_types,
                 interpolate=self.interpolate,
             )
         return self._lookup
@@ -357,6 +362,7 @@ class Weather:
             day_column=day_column,
             db=self.db,
             units=self.units,
+            include_weather_types=self.include_weather_types,
             parallel=parallel,
             max_workers=max_workers,
         )

--- a/src/get_weather_data/weather/batch.py
+++ b/src/get_weather_data/weather/batch.py
@@ -20,6 +20,7 @@ from get_weather_data.core.database import Database
 from get_weather_data.weather.lookup import WeatherLookup
 from get_weather_data.weather.results import WeatherResult
 from get_weather_data.weather.units import ELEMENTS, Units
+from get_weather_data.weather.weather_types import format_weather_types
 
 logger = logging.getLogger("get_weather_data")
 
@@ -35,6 +36,13 @@ _STATION_COLUMNS = [
 # sync as elements are added.
 _VALUE_COLUMNS = [spec.field for spec in ELEMENTS.values()]
 WEATHER_COLUMNS = [*_STATION_COLUMNS, *_VALUE_COLUMNS, "weather_error"]
+
+
+def _weather_columns(include_weather_types: bool) -> list[str]:
+    """Output weather columns, optionally including weather_types."""
+    if not include_weather_types:
+        return WEATHER_COLUMNS
+    return [*_STATION_COLUMNS, *_VALUE_COLUMNS, "weather_types", "weather_error"]
 
 
 @dataclass
@@ -59,6 +67,7 @@ def process_csv(
     day_column: str | int | None = "day",
     db: Database | None = None,
     units: Units = "metric",
+    include_weather_types: bool = False,
     parallel: bool = True,
     max_workers: int | None = None,
 ) -> int:
@@ -77,6 +86,8 @@ def process_csv(
         day_column: Column name or index for day.
         db: Database instance. Uses default if None.
         units: Unit system for the output values.
+        include_weather_types: If True, add a ``weather_types`` column
+            with the day's present-weather phenomena (comma-joined).
         parallel: Use parallel processing for faster execution.
         max_workers: Number of worker threads (default: CPU count).
 
@@ -91,7 +102,10 @@ def process_csv(
     if max_workers is None:
         max_workers = min(os.cpu_count() or 4, 8)
 
-    lookup = WeatherLookup(db=db, units=units)
+    lookup = WeatherLookup(
+        db=db, units=units, include_weather_types=include_weather_types
+    )
+    weather_columns = _weather_columns(include_weather_types)
 
     def parse_row(row: dict[str, str]) -> _Row:
         location: str | tuple[float, float] | None = None
@@ -137,7 +151,7 @@ def process_csv(
         open(output_path, "w", encoding="utf-8", newline="") as outfile,
     ):
         reader = csv.DictReader(infile)
-        fieldnames = list(reader.fieldnames or []) + WEATHER_COLUMNS
+        fieldnames = list(reader.fieldnames or []) + weather_columns
         writer = csv.DictWriter(outfile, fieldnames=fieldnames)
         writer.writeheader()
         outfile.flush()
@@ -154,7 +168,9 @@ def process_csv(
                     outputs = [process_row(parsed) for parsed in chunk]
 
                 for row_data, result, error in outputs:
-                    row_data.update(_result_to_dict(result, error))
+                    row_data.update(
+                        _result_to_dict(result, error, include_weather_types)
+                    )
                     writer.writerow(row_data)
                     if error:
                         errors += 1
@@ -212,13 +228,20 @@ def _cell(value: object) -> str:
     return "" if value is None else str(value)
 
 
-def _result_to_dict(result: WeatherResult | None, error: str) -> dict[str, str]:
+def _result_to_dict(
+    result: WeatherResult | None,
+    error: str,
+    include_weather_types: bool = False,
+) -> dict[str, str]:
     """Convert a WeatherResult (or an error) to CSV output columns."""
+    columns = _weather_columns(include_weather_types)
     if result is None:
-        empty = dict.fromkeys(WEATHER_COLUMNS, "")
+        empty = dict.fromkeys(columns, "")
         empty["weather_error"] = error
         return empty
     row = {column: _cell(getattr(result, column)) for column in _STATION_COLUMNS}
     row.update({field: _cell(getattr(result, field)) for field in _VALUE_COLUMNS})
+    if include_weather_types:
+        row["weather_types"] = format_weather_types(result.weather_types)
     row["weather_error"] = error
     return row

--- a/src/get_weather_data/weather/frame.py
+++ b/src/get_weather_data/weather/frame.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from get_weather_data.weather.results import WeatherResult
 from get_weather_data.weather.units import ELEMENTS
+from get_weather_data.weather.weather_types import format_weather_types
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -72,6 +73,12 @@ def results_to_frame(results: Sequence[WeatherResult]) -> "pd.DataFrame":
     rows = [
         {column: getattr(result, column) for column in columns} for result in results
     ]
+    # Present-weather phenomena are only collected on request; add the
+    # column (comma-joined, sorted) only when at least one result has it.
+    if any(result.weather_types is not None for result in results):
+        columns = [*columns, "weather_types"]
+        for row, result in zip(rows, results, strict=True):
+            row["weather_types"] = format_weather_types(result.weather_types)
     frame = pd.DataFrame(rows, columns=columns)
     frame["date"] = pd.to_datetime(frame["date"])
     return frame

--- a/src/get_weather_data/weather/ghcn.py
+++ b/src/get_weather_data/weather/ghcn.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from get_weather_data.core.cache import is_fresh, year_is_immutable
 from get_weather_data.core.config import get_config
 from get_weather_data.core.download import download_with_retry
+from get_weather_data.weather.weather_types import WT_CODES
 
 logger = logging.getLogger("get_weather_data")
 
@@ -244,3 +245,18 @@ def get_ghcn_flags(
         elements = GHCN_ELEMENTS
     rows = _read_ghcn_rows(station_id, target_date, elements)
     return {element: q_flag for element, (_value, q_flag) in rows.items()}
+
+
+def get_ghcn_weather_types(station_id: str, target_date: date) -> set[str]:
+    """Get present-weather phenomena for a GHCN station and date.
+
+    Args:
+        station_id: GHCN station ID.
+        target_date: Date to read.
+
+    Returns:
+        Set of phenomenon names (e.g. {"fog", "thunder"}) from the day's
+        WT** occurrence codes.
+    """
+    rows = _read_ghcn_rows(station_id, target_date, list(WT_CODES))
+    return {WT_CODES[code] for code in rows if code in WT_CODES}

--- a/src/get_weather_data/weather/gsod.py
+++ b/src/get_weather_data/weather/gsod.py
@@ -9,6 +9,7 @@ from get_weather_data.core.cache import is_fresh, year_is_immutable
 from get_weather_data.core.config import get_config
 from get_weather_data.core.download import download_with_retry
 from get_weather_data.weather.units import KNOTS_TO_MS, f_to_c
+from get_weather_data.weather.weather_types import parse_frshtt
 
 logger = logging.getLogger("get_weather_data")
 
@@ -105,3 +106,26 @@ def get_gsod_data(
                 break
 
     return values
+
+
+def get_gsod_weather_types(station_id: str, target_date: date) -> set[str]:
+    """Get present-weather phenomena for a GSOD station and date.
+
+    Args:
+        station_id: USAF-WBAN station ID.
+        target_date: Date to read.
+
+    Returns:
+        Set of phenomenon names parsed from the day's FRSHTT indicator.
+    """
+    year = target_date.year
+    file_path = _ensure_gsod_file(station_id, year)
+    if file_path is None:
+        return set()
+
+    date_str = target_date.strftime("%Y-%m-%d")
+    with open(file_path, encoding="utf-8", errors="replace") as f:
+        for row in csv.DictReader(f):
+            if row.get("DATE") == date_str:
+                return parse_frshtt(row.get("FRSHTT", "").strip())
+    return set()

--- a/src/get_weather_data/weather/lookup.py
+++ b/src/get_weather_data/weather/lookup.py
@@ -7,8 +7,12 @@ from functools import lru_cache
 
 from get_weather_data.core.database import INDEX_VERSION, Database
 from get_weather_data.core.distance import find_closest
-from get_weather_data.weather.ghcn import get_ghcn_data, get_ghcn_flags
-from get_weather_data.weather.gsod import get_gsod_data
+from get_weather_data.weather.ghcn import (
+    get_ghcn_data,
+    get_ghcn_flags,
+    get_ghcn_weather_types,
+)
+from get_weather_data.weather.gsod import get_gsod_data, get_gsod_weather_types
 from get_weather_data.weather.interpolate import Sample, idw
 from get_weather_data.weather.location import LocationInput, parse_location
 from get_weather_data.weather.results import (
@@ -96,6 +100,7 @@ class WeatherLookup:
     use_gsod: bool = True
     use_cache: bool = True
     include_flags: bool = False
+    include_weather_types: bool = False
     interpolate: bool = False
     idw_power: float = 2.0
     interpolate_stations: int = 5
@@ -168,6 +173,7 @@ class WeatherLookup:
 
         values: dict[str, float] = {}
         flags: dict[str, str] = {}
+        weather_types: set[str] = set()
         station = StationMeta()
 
         for station_id, distance in closest[: self.max_stations]:
@@ -180,6 +186,11 @@ class WeatherLookup:
             if not station_info:
                 continue
             station_name, station_type = station_info
+
+            if self.include_weather_types:
+                weather_types |= self._station_weather_types(
+                    station_id, station_type, target_date
+                )
 
             metric = self._station_values(station_id, station_type, target_date)
             new_elements = {
@@ -215,6 +226,8 @@ class WeatherLookup:
         if self.include_flags and flags:
             # Re-key flags from GHCN codes to result field names
             result.flags = {ELEMENTS[e].field: f for e, f in flags.items()}
+        if self.include_weather_types:
+            result.weather_types = weather_types
         return result
 
     def _interpolate(
@@ -329,6 +342,16 @@ class WeatherLookup:
     def _station_flags(self, station_id: str, target_date: date) -> dict[str, str]:
         """GHCN quality-control flags for a station-day (GHCN elements)."""
         return get_ghcn_flags(station_id, target_date)
+
+    def _station_weather_types(
+        self, station_id: str, station_type: str, target_date: date
+    ) -> set[str]:
+        """Present-weather phenomena for a station-day (source-dependent)."""
+        if station_type == "GHCND" and self.use_ghcn:
+            return get_ghcn_weather_types(station_id, target_date)
+        if station_type == "USAF-WBAN" and self.use_gsod:
+            return get_gsod_weather_types(station_id, target_date)
+        return set()
 
     def get_weather_range(
         self,

--- a/src/get_weather_data/weather/online.py
+++ b/src/get_weather_data/weather/online.py
@@ -29,6 +29,7 @@ from get_weather_data.weather.units import (
     ghcn_raw_to_metric,
     normalize_elements,
 )
+from get_weather_data.weather.weather_types import WT_CODES
 
 logger = logging.getLogger("get_weather_data")
 
@@ -51,6 +52,7 @@ class OnlineLookup:
 
     client: NOAAClient = field(default_factory=NOAAClient)
     units: Units = "metric"
+    include_weather_types: bool = False
     # Dense CoCoRaHS networks (precip/snow-only community observers) can
     # fill the nearest ranks in a metro, crowding out the airport station
     # that carries temperature; keep the search wide enough to reach it.
@@ -229,11 +231,16 @@ class OnlineLookup:
         """Assemble one day's result from CDO records, nearest first."""
         wanted = set(requested)
         by_station: dict[str, dict[str, float]] = defaultdict(dict)
+        weather_types: set[str] = set()
         for record in records:
             datatype = record.get("datatype")
             station = record.get("station")
             value = record.get("value")
-            if not datatype or not station or value is None or datatype not in wanted:
+            if not datatype or not station:
+                continue
+            if self.include_weather_types and datatype in WT_CODES:
+                weather_types.add(WT_CODES[datatype])
+            if value is None or datatype not in wanted:
                 continue
             by_station[station][datatype] = ghcn_raw_to_metric(datatype, float(value))
 
@@ -254,7 +261,7 @@ class OnlineLookup:
             for element, value in station_values.items():
                 values.setdefault(element, value)
 
-        return assemble_result(
+        result = assemble_result(
             target_date=target_date,
             metric_values=values,
             station=meta,
@@ -264,6 +271,9 @@ class OnlineLookup:
             latitude=lat,
             longitude=lon,
         )
+        if self.include_weather_types:
+            result.weather_types = weather_types
+        return result
 
 
 def _record_date(record: dict[str, Any]) -> date | None:

--- a/src/get_weather_data/weather/results.py
+++ b/src/get_weather_data/weather/results.py
@@ -43,6 +43,8 @@ class WeatherResult:
         flags: Per-field GHCN quality-control flag, when include_flags is
             set; a blank flag means the value passed all QC checks
             (GHCN stations only).
+        weather_types: Present-weather phenomena for the day (e.g.
+            {"fog", "thunder"}), when include_weather_types is set.
     """
 
     date: date_type
@@ -68,6 +70,7 @@ class WeatherResult:
     station_pressure: float | None = None
     visibility: float | None = None
     flags: dict[str, str] | None = None
+    weather_types: set[str] | None = None
 
 
 @dataclass

--- a/src/get_weather_data/weather/weather_types.py
+++ b/src/get_weather_data/weather/weather_types.py
@@ -1,0 +1,79 @@
+"""Weather-type (present-weather) phenomena.
+
+GHCN daily files carry ``WT**`` occurrence codes (value ``1`` = the
+phenomenon occurred that day); GSOD carries a 6-character ``FRSHTT``
+indicator. Both are occurrence flags without units, so they live outside
+the numeric element registry. This module maps both to a common set of
+lowercase phenomenon names.
+"""
+
+# GHCN WT** code -> phenomenon name (GHCN-Daily readme).
+WT_CODES: dict[str, str] = {
+    "WT01": "fog",
+    "WT02": "heavy_fog",
+    "WT03": "thunder",
+    "WT04": "sleet",
+    "WT05": "hail",
+    "WT06": "glaze",
+    "WT07": "blowing_dust",
+    "WT08": "smoke_haze",
+    "WT09": "blowing_snow",
+    "WT10": "tornado",
+    "WT11": "high_winds",
+    "WT12": "blowing_spray",
+    "WT13": "mist",
+    "WT14": "drizzle",
+    "WT15": "freezing_drizzle",
+    "WT16": "rain",
+    "WT17": "freezing_rain",
+    "WT18": "snow",
+    "WT19": "unknown_precip",
+    "WT21": "ground_fog",
+    "WT22": "ice_fog",
+}
+
+# GSOD FRSHTT indicator: one character per phenomenon, in order.
+FRSHTT_ORDER = ("fog", "rain", "snow", "hail", "thunder", "tornado")
+
+
+def ghcn_weather_type(code: str) -> str | None:
+    """Phenomenon name for a GHCN element code, or None if not a WT code.
+
+    Args:
+        code: GHCN element code (e.g. "WT03").
+
+    Returns:
+        The phenomenon name, or None.
+    """
+    return WT_CODES.get(code)
+
+
+def format_weather_types(types: set[str] | None) -> str:
+    """Render a weather-type set as a stable, comma-joined string.
+
+    Args:
+        types: Phenomenon names, or None when not collected.
+
+    Returns:
+        Sorted comma-joined names (e.g. "fog,thunder"), or "" when the
+        set is empty or None.
+    """
+    if not types:
+        return ""
+    return ",".join(sorted(types))
+
+
+def parse_frshtt(indicator: str) -> set[str]:
+    """Parse a GSOD FRSHTT indicator into phenomenon names.
+
+    Args:
+        indicator: The 6-character FRSHTT string (e.g. "010001").
+
+    Returns:
+        Set of phenomena flagged as present.
+    """
+    phenomena = set()
+    for name, char in zip(FRSHTT_ORDER, indicator.strip(), strict=False):
+        if char == "1":
+            phenomena.add(name)
+    return phenomena

--- a/tests/test_e2e_live.py
+++ b/tests/test_e2e_live.py
@@ -101,3 +101,19 @@ def test_grid_and_online_agree():
         pytest.skip("no overlapping data")
     gap = min(abs(online.tmax - v) for v in grid.values() if v is not None)
     assert gap < 4.0
+
+
+@online_only
+def test_weather_types_thunderstorm_day():
+    """A NYC-area summer thunderstorm day flags thunder via WT** codes."""
+    w = Weather(online=True, include_weather_types=True)
+    r = w.get("11430", date(2023, 7, 16))  # JFK area
+    assert r.weather_types is not None
+    assert "thunder" in r.weather_types
+
+
+@online_only
+def test_weather_types_off_by_default():
+    """Without the flag, weather_types stays None."""
+    r = _online().get("11430", date(2023, 7, 16))
+    assert r.weather_types is None

--- a/tests/test_weather_types.py
+++ b/tests/test_weather_types.py
@@ -1,0 +1,267 @@
+"""Tests for present-weather phenomena (WT** / FRSHTT) end to end."""
+
+import csv
+import gzip
+import io
+from datetime import date
+
+import pytest
+import respx
+from httpx import Response
+
+from get_weather_data.core.config import Config, set_config
+from get_weather_data.core.database import INDEX_VERSION, Database
+from get_weather_data.core.distance import Station
+from get_weather_data.weather import ghcn
+from get_weather_data.weather import gsod as gsod_module
+from get_weather_data.weather import lookup as lookup_module
+from get_weather_data.weather.ghcn import get_ghcn_weather_types
+from get_weather_data.weather.gsod import get_gsod_weather_types
+from get_weather_data.weather.lookup import WeatherLookup
+from get_weather_data.weather.online import OnlineLookup
+from get_weather_data.weather.weather_types import (
+    format_weather_types,
+    ghcn_weather_type,
+    parse_frshtt,
+)
+
+DAY = date(2010, 1, 15)
+
+
+class TestParsingHelpers:
+    def test_ghcn_weather_type_known_and_unknown(self):
+        assert ghcn_weather_type("WT01") == "fog"
+        assert ghcn_weather_type("WT03") == "thunder"
+        assert ghcn_weather_type("TMAX") is None
+
+    def test_parse_frshtt(self):
+        # FRSHTT order: fog, rain, snow, hail, thunder, tornado
+        assert parse_frshtt("010001") == {"rain", "tornado"}
+        assert parse_frshtt("100010") == {"fog", "thunder"}
+        assert parse_frshtt("000000") == set()
+
+    def test_parse_frshtt_handles_short_or_blank(self):
+        assert parse_frshtt("") == set()
+        assert parse_frshtt("1") == {"fog"}
+
+    def test_format_weather_types_sorted_and_joined(self):
+        assert format_weather_types({"thunder", "fog"}) == "fog,thunder"
+
+    def test_format_weather_types_empty(self):
+        assert format_weather_types(set()) == ""
+        assert format_weather_types(None) == ""
+
+
+@pytest.fixture(autouse=True)
+def _isolated_ghcn(tmp_path, monkeypatch):
+    """Point GHCN caches at a temp dir and reset module-level pools."""
+    monkeypatch.delenv("NCDC_TOKEN", raising=False)
+    set_config(Config(ncdc_token=None, data_dir=tmp_path, cache_dir=tmp_path))
+    ghcn._year_locks.clear()
+    if hasattr(ghcn._connections, "pool"):
+        del ghcn._connections.pool
+    yield
+    if hasattr(ghcn._connections, "pool"):
+        del ghcn._connections.pool
+
+
+def _year_gz_bytes(rows: list[tuple]) -> bytes:
+    buf = io.StringIO()
+    csv.writer(buf).writerows(rows)
+    return gzip.compress(buf.getvalue().encode())
+
+
+class TestGhcnWeatherTypes:
+    @respx.mock
+    def test_reads_wt_occurrence_codes(self):
+        rows = [
+            ("USW00094728", "20100115", "TMAX", "-10", "", "", "W", ""),
+            ("USW00094728", "20100115", "WT01", "1", "", "", "W", ""),
+            ("USW00094728", "20100115", "WT03", "1", "", "", "W", ""),
+            # A non-WT element must be ignored
+            ("USW00094728", "20100115", "PRCP", "0", "", "", "W", ""),
+        ]
+        respx.get(ghcn.GHCN_BY_YEAR_URL.format(year=2010)).mock(
+            return_value=Response(200, content=_year_gz_bytes(rows))
+        )
+        assert get_ghcn_weather_types("USW00094728", DAY) == {"fog", "thunder"}
+
+    @respx.mock
+    def test_absent_day_is_empty(self):
+        rows = [("USW00094728", "20100115", "WT01", "1", "", "", "W", "")]
+        respx.get(ghcn.GHCN_BY_YEAR_URL.format(year=2010)).mock(
+            return_value=Response(200, content=_year_gz_bytes(rows))
+        )
+        assert get_ghcn_weather_types("USW00094728", date(2010, 6, 1)) == set()
+
+
+GSOD_HEADER = "STATION,DATE,TEMP,FRSHTT\n"
+
+
+class TestGsodWeatherTypes:
+    @pytest.fixture
+    def gsod_file(self, tmp_path, monkeypatch):
+        path = tmp_path / "725030.csv"
+        # 2010-01-15: rain + snow + thunder (FRSHTT = 011010)
+        path.write_text(
+            GSOD_HEADER
+            + "725030,2010-01-15,40.0,011010\n"
+            + "725030,2010-01-16,50.0,000000\n"
+        )
+        monkeypatch.setattr(gsod_module, "_ensure_gsod_file", lambda sid, yr: path)
+        return path
+
+    def test_parses_frshtt(self, gsod_file):
+        assert get_gsod_weather_types("725030", DAY) == {"rain", "snow", "thunder"}
+
+    def test_clear_day_empty(self, gsod_file):
+        assert get_gsod_weather_types("725030", date(2010, 1, 16)) == set()
+
+    def test_missing_file_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gsod_module, "_ensure_gsod_file", lambda sid, yr: None)
+        assert get_gsod_weather_types("725030", DAY) == set()
+
+
+@pytest.fixture
+def city_db(tmp_path) -> Database:
+    db = Database(tmp_path / "city.sqlite")
+    db.init_schema()
+    db.insert_zipcode("10001", "New York", "NY", 40.7484, -73.9967)
+    db.insert_station(
+        Station(id="GHCN1", name="GHCN STATION", lat=40.78, lon=-73.97, type="GHCND")
+    )
+    db.insert_station(
+        Station(
+            id="725030-14732",
+            name="GSOD STATION",
+            lat=40.78,
+            lon=-73.88,
+            type="USAF-WBAN",
+        )
+    )
+    db.set_closest_stations_bulk({"10001": [("GHCN1", 4000), ("725030-14732", 9000)]})
+    db.set_meta("index_version", str(INDEX_VERSION))
+    return db
+
+
+class TestLookupPlumbing:
+    def test_off_by_default(self, city_db, monkeypatch):
+        monkeypatch.setattr(
+            lookup_module, "get_ghcn_data", lambda sid, d: {"TMAX": -100.0}
+        )
+        result = WeatherLookup(db=city_db, use_cache=False).get_weather("10001", DAY)
+        assert result.weather_types is None
+
+    def test_collects_from_ghcn(self, city_db, monkeypatch):
+        monkeypatch.setattr(
+            lookup_module, "get_ghcn_data", lambda sid, d: {"TMAX": -100.0}
+        )
+        monkeypatch.setattr(
+            lookup_module,
+            "get_ghcn_weather_types",
+            lambda sid, d: {"fog", "thunder"},
+        )
+        result = WeatherLookup(
+            db=city_db, use_cache=False, include_weather_types=True
+        ).get_weather("10001", DAY)
+        assert result.weather_types == {"fog", "thunder"}
+
+    def test_unions_across_stations(self, city_db, monkeypatch):
+        # GHCN supplies no values so the loop keeps walking to the GSOD
+        # station; phenomena from both must union.
+        monkeypatch.setattr(lookup_module, "get_ghcn_data", lambda sid, d: {})
+        monkeypatch.setattr(lookup_module, "get_gsod_data", lambda sid, d: {})
+        monkeypatch.setattr(
+            lookup_module, "get_ghcn_weather_types", lambda sid, d: {"fog"}
+        )
+        monkeypatch.setattr(
+            lookup_module, "get_gsod_weather_types", lambda sid, d: {"snow"}
+        )
+        result = WeatherLookup(
+            db=city_db, use_cache=False, include_weather_types=True
+        ).get_weather("10001", DAY)
+        assert result.weather_types == {"fog", "snow"}
+
+
+class TestOnlinePlumbing:
+    def _records(self):
+        return [
+            {
+                "date": "2010-01-15T00:00:00",
+                "datatype": "TMAX",
+                "station": "S1",
+                "value": -100.0,
+            },
+            {
+                "date": "2010-01-15T00:00:00",
+                "datatype": "WT01",
+                "station": "S1",
+                "value": 1.0,
+            },
+            {
+                "date": "2010-01-15T00:00:00",
+                "datatype": "WT03",
+                "station": "S1",
+                "value": 1.0,
+            },
+        ]
+
+    def _online(self, **kwargs) -> OnlineLookup:
+        from get_weather_data.api.noaa import NOAAClient
+
+        kwargs.setdefault("client", NOAAClient(token="test"))
+        return OnlineLookup(**kwargs)
+
+    def _stations(self):
+        from get_weather_data.api.noaa import StationInfo
+
+        return [(StationInfo(id="S1", name="A", latitude=40.0, longitude=-73.0), 100)]
+
+    def test_collects_wt_datatypes(self):
+        online = self._online(include_weather_types=True)
+        result = online._build_result(
+            date(2010, 1, 15),
+            self._records(),
+            self._stations(),
+            ["TMAX"],
+            None,
+            40.0,
+            -73.0,
+        )
+        assert result.weather_types == {"fog", "thunder"}
+
+    def test_off_by_default(self):
+        online = self._online()
+        result = online._build_result(
+            date(2010, 1, 15),
+            self._records(),
+            self._stations(),
+            ["TMAX"],
+            None,
+            40.0,
+            -73.0,
+        )
+        assert result.weather_types is None
+
+
+class TestOutputColumns:
+    def test_frame_column_only_when_present(self):
+        pd = pytest.importorskip("pandas")
+        from get_weather_data.weather.frame import results_to_frame
+        from get_weather_data.weather.results import WeatherResult
+
+        without = results_to_frame([WeatherResult(date=DAY)])
+        assert "weather_types" not in without.columns
+
+        with_types = results_to_frame(
+            [WeatherResult(date=DAY, weather_types={"fog", "thunder"})]
+        )
+        assert with_types["weather_types"].iloc[0] == "fog,thunder"
+        assert pd.notna(with_types["weather_types"].iloc[0])
+
+    def test_batch_columns(self):
+        from get_weather_data.weather.batch import _weather_columns
+
+        assert "weather_types" not in _weather_columns(False)
+        cols = _weather_columns(True)
+        assert cols.index("weather_types") == cols.index("weather_error") - 1


### PR DESCRIPTION
## Summary

Phase 2 of the niche-win roadmap: **present-weather phenomena**, plus a small library-logging fix.

- `Weather(include_weather_types=True)` populates `result.weather_types` — a set like `{"fog", "thunder"}` — from GHCN `WT**` occurrence codes and GSOD's `FRSHTT` indicator, on **both** the station and online backends.
- Surfaced everywhere: `get-weather get <loc> <date> --weather-types` (table row), `get-weather process --weather-types` (comma-joined `weather_types` CSV column), and `get_frame(...)` (column added when the data carries it).
- **Logging hygiene**: attach a `NullHandler` to the `get_weather_data` logger so importing the package never emits log output unless the host app configures logging.

## Verification

- Full local gate green: ruff, ruff format, pyright (0 errors), pydoclint, `sphinx -W`, `pytest --cov` **214 passed / 90.09%** (floor 85).
- New `tests/test_weather_types.py` (17 tests): FRSHTT/WT parsing, real GHCN yearly-DB build with WT rows, GSOD FRSHTT reader, lookup + online plumbing, frame/batch columns.
- Live-audited: JFK 2023-07-16 → `{fog, heavy_fog, thunder}` via the online backend; two new `-m live` E2E tests assert a thunderstorm day flags `thunder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)