### PR TITLE
Missing-data provenance via explain=True (v5.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Notable changes to get-weather-data. Versions follow the git tags.
 
+## 5.3.0
+
+Added
+
+- Missing-data provenance: `Weather(explain=True)` populates
+  `result.stations_considered` and `result.missing` — a per-field
+  reason each requested value is absent (station coverage, distance
+  cap, unknown ZIP, ...), on both the station and online backends.
+  Surfaced via `get --explain`, `process --explain` (adds
+  `stations_considered` and `missing` CSV columns), and `get_frame`.
+- A `debug`-level log line naming the fields still missing after the
+  station walk, for `verbose=True` diagnosis.
+
 ## 5.2.0
 
 Added

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Notes on online mode:
 - **Present weather**: `include_weather_types=True` reports the day's
   phenomena (fog, thunder, hail, freezing rain, ...) from GHCN `WT**`
   codes and GSOD's `FRSHTT` indicator
+- **Explainable gaps**: `explain=True` tells you *why* a value is
+  missing (`stations_considered` + a per-field `missing` reason) — a
+  blank cell becomes diagnosable, not silent
 - **Automatic station selection**: nearest station first, farther
   stations fill in missing variables; `coverage(...)` reports how well
   a point is served
@@ -248,6 +251,27 @@ print(sorted(r.weather_types))  # ['fog', 'heavy_fog', 'thunder']
 `get-weather get <loc> <date> --weather-types` shows them on the CLI,
 and `process --weather-types` adds a comma-joined `weather_types`
 column to the batch CSV.
+
+### Why is a value missing?
+
+A blank `tmax` could mean many things: no station nearby, a station
+that measures only precipitation, or a gap on that date. With
+`explain=True`, the result carries `stations_considered` and a
+`missing` map giving a reason for each requested field that came back
+empty:
+
+```python
+w = Weather(online=True, explain=True)
+r = w.get("59221", "2023-01-15")  # remote NE Montana
+print(r.stations_considered)  # e.g. 20
+print(r.missing.get("tmax"))
+# 'none of the 20 CDO stations near this point reported tmax on 2023-01-15'
+```
+
+`get --explain` prints the reasons on the CLI, `process --explain` adds
+`stations_considered` and `missing` columns to the batch CSV, and
+`get_frame(...)` includes them when present. (For a data consumer,
+this turns a silent `NaN` into a diagnosable gap.)
 
 ## Which backend?
 

--- a/src/get_weather_data/cli.py
+++ b/src/get_weather_data/cli.py
@@ -104,6 +104,11 @@ def setup(
     is_flag=True,
     help="Also report present-weather phenomena (fog, thunder, hail, ...)",
 )
+@click.option(
+    "--explain",
+    is_flag=True,
+    help="Explain why any requested value is missing (station coverage)",
+)
 @click.pass_context
 def get(
     ctx: click.Context,
@@ -114,6 +119,7 @@ def get(
     source: str,
     online: bool,
     weather_types: bool,
+    explain: bool,
 ) -> None:
     """Get weather data for a location and date.
 
@@ -130,6 +136,7 @@ def get(
             units=units,  # type: ignore[arg-type]
             source=source,  # type: ignore[arg-type]
             include_weather_types=weather_types,
+            explain=explain,
         )
         element_list = elements.split(",") if elements else None
         result = weather.get(location, target_date, elements=element_list)
@@ -169,6 +176,16 @@ def get(
 
     console.print(table)
 
+    if explain:
+        considered = result.stations_considered
+        console.print(f"\nStations examined: {considered if considered else 0}")
+        if result.missing:
+            console.print("[yellow]Missing values:[/yellow]")
+            for field_name, reason in result.missing.items():
+                console.print(f"  • {field_name}: {reason}")
+        else:
+            console.print("[green]All requested values were found.[/green]")
+
 
 @cli.command()
 @click.argument("input_file", type=click.Path(exists=True))
@@ -191,6 +208,11 @@ def get(
     is_flag=True,
     help="Add a weather_types column with present-weather phenomena",
 )
+@click.option(
+    "--explain",
+    is_flag=True,
+    help="Add stations_considered and missing columns explaining gaps",
+)
 @click.option("--parallel/--no-parallel", default=True, help="Use parallel processing")
 @click.option("--workers", type=int, help="Number of worker threads (default: auto)")
 @click.pass_context
@@ -207,6 +229,7 @@ def process(
     month_column: str,
     day_column: str,
     weather_types: bool,
+    explain: bool,
     parallel: bool,
     workers: int | None,
 ) -> None:
@@ -223,6 +246,7 @@ def process(
         verbose=ctx.obj["verbose"],
         units=units,  # type: ignore[arg-type]
         include_weather_types=weather_types,
+        explain=explain,
     )
 
     mode = "parallel" if parallel else "sequential"

--- a/src/get_weather_data/main.py
+++ b/src/get_weather_data/main.py
@@ -63,6 +63,7 @@ class Weather:
     units: Units = "metric"
     include_flags: bool = False
     include_weather_types: bool = False
+    explain: bool = False
     interpolate: bool = False
     source: Source = "station"
     _db: Database | None = field(default=None, repr=False)
@@ -87,6 +88,7 @@ class Weather:
             self._online_lookup = OnlineLookup(
                 units=self.units,
                 include_weather_types=self.include_weather_types,
+                explain=self.explain,
             )
         else:
             self._db = Database(self.database_path)
@@ -107,6 +109,7 @@ class Weather:
                 units=self.units,
                 include_flags=self.include_flags,
                 include_weather_types=self.include_weather_types,
+                explain=self.explain,
                 interpolate=self.interpolate,
             )
         return self._lookup
@@ -363,6 +366,7 @@ class Weather:
             db=self.db,
             units=self.units,
             include_weather_types=self.include_weather_types,
+            explain=self.explain,
             parallel=parallel,
             max_workers=max_workers,
         )

--- a/src/get_weather_data/weather/batch.py
+++ b/src/get_weather_data/weather/batch.py
@@ -38,11 +38,15 @@ _VALUE_COLUMNS = [spec.field for spec in ELEMENTS.values()]
 WEATHER_COLUMNS = [*_STATION_COLUMNS, *_VALUE_COLUMNS, "weather_error"]
 
 
-def _weather_columns(include_weather_types: bool) -> list[str]:
-    """Output weather columns, optionally including weather_types."""
-    if not include_weather_types:
-        return WEATHER_COLUMNS
-    return [*_STATION_COLUMNS, *_VALUE_COLUMNS, "weather_types", "weather_error"]
+def _weather_columns(include_weather_types: bool, explain: bool = False) -> list[str]:
+    """Output weather columns, optionally with weather_types/provenance."""
+    columns = [*_STATION_COLUMNS, *_VALUE_COLUMNS]
+    if include_weather_types:
+        columns.append("weather_types")
+    if explain:
+        columns += ["stations_considered", "missing"]
+    columns.append("weather_error")
+    return columns
 
 
 @dataclass
@@ -68,6 +72,7 @@ def process_csv(
     db: Database | None = None,
     units: Units = "metric",
     include_weather_types: bool = False,
+    explain: bool = False,
     parallel: bool = True,
     max_workers: int | None = None,
 ) -> int:
@@ -88,6 +93,8 @@ def process_csv(
         units: Unit system for the output values.
         include_weather_types: If True, add a ``weather_types`` column
             with the day's present-weather phenomena (comma-joined).
+        explain: If True, add ``stations_considered`` and ``missing``
+            columns explaining why any requested value is absent.
         parallel: Use parallel processing for faster execution.
         max_workers: Number of worker threads (default: CPU count).
 
@@ -103,9 +110,12 @@ def process_csv(
         max_workers = min(os.cpu_count() or 4, 8)
 
     lookup = WeatherLookup(
-        db=db, units=units, include_weather_types=include_weather_types
+        db=db,
+        units=units,
+        include_weather_types=include_weather_types,
+        explain=explain,
     )
-    weather_columns = _weather_columns(include_weather_types)
+    weather_columns = _weather_columns(include_weather_types, explain)
 
     def parse_row(row: dict[str, str]) -> _Row:
         location: str | tuple[float, float] | None = None
@@ -169,7 +179,7 @@ def process_csv(
 
                 for row_data, result, error in outputs:
                     row_data.update(
-                        _result_to_dict(result, error, include_weather_types)
+                        _result_to_dict(result, error, include_weather_types, explain)
                     )
                     writer.writerow(row_data)
                     if error:
@@ -232,9 +242,10 @@ def _result_to_dict(
     result: WeatherResult | None,
     error: str,
     include_weather_types: bool = False,
+    explain: bool = False,
 ) -> dict[str, str]:
     """Convert a WeatherResult (or an error) to CSV output columns."""
-    columns = _weather_columns(include_weather_types)
+    columns = _weather_columns(include_weather_types, explain)
     if result is None:
         empty = dict.fromkeys(columns, "")
         empty["weather_error"] = error
@@ -243,5 +254,15 @@ def _result_to_dict(
     row.update({field: _cell(getattr(result, field)) for field in _VALUE_COLUMNS})
     if include_weather_types:
         row["weather_types"] = format_weather_types(result.weather_types)
+    if explain:
+        row["stations_considered"] = _cell(result.stations_considered)
+        row["missing"] = _format_missing(result.missing)
     row["weather_error"] = error
     return row
+
+
+def _format_missing(missing: dict[str, str] | None) -> str:
+    """Render a per-field missing-reason map as one compact CSV cell."""
+    if not missing:
+        return ""
+    return "; ".join(f"{field}: {reason}" for field, reason in missing.items())

--- a/src/get_weather_data/weather/frame.py
+++ b/src/get_weather_data/weather/frame.py
@@ -31,6 +31,21 @@ _META_COLUMNS = [
 _VALUE_COLUMNS = [spec.field for spec in ELEMENTS.values()]
 
 
+def _format_missing(missing: dict[str, str] | None) -> str:
+    """Render a per-field missing-reason map as one compact cell.
+
+    Args:
+        missing: Field name -> reason, or None.
+
+    Returns:
+        "field: reason; field: reason" for each entry, or "" when the
+        map is empty or None.
+    """
+    if not missing:
+        return ""
+    return "; ".join(f"{field}: {reason}" for field, reason in missing.items())
+
+
 def _require_pandas() -> "Any":
     """Import pandas or raise a helpful error.
 
@@ -79,6 +94,12 @@ def results_to_frame(results: Sequence[WeatherResult]) -> "pd.DataFrame":
         columns = [*columns, "weather_types"]
         for row, result in zip(rows, results, strict=True):
             row["weather_types"] = format_weather_types(result.weather_types)
+    # Provenance columns appear only when explain=True populated them.
+    if any(result.stations_considered is not None for result in results):
+        columns = [*columns, "stations_considered", "missing"]
+        for row, result in zip(rows, results, strict=True):
+            row["stations_considered"] = result.stations_considered
+            row["missing"] = _format_missing(result.missing)
     frame = pd.DataFrame(rows, columns=columns)
     frame["date"] = pd.to_datetime(frame["date"])
     return frame

--- a/src/get_weather_data/weather/lookup.py
+++ b/src/get_weather_data/weather/lookup.py
@@ -101,6 +101,7 @@ class WeatherLookup:
     use_cache: bool = True
     include_flags: bool = False
     include_weather_types: bool = False
+    explain: bool = False
     interpolate: bool = False
     idw_power: float = 2.0
     interpolate_stations: int = 5
@@ -149,9 +150,14 @@ class WeatherLookup:
             coords = self.db.get_zipcode(zipcode)
             if coords is None:
                 logger.warning(f"ZIP code {zipcode} not found in database")
-                return WeatherResult(
+                result = WeatherResult(
                     date=target_date, zipcode=zipcode, units=self.units
                 )
+                if self.explain:
+                    reason = f"ZIP code {zipcode} is not in the station database"
+                    result.stations_considered = 0
+                    result.missing = {ELEMENTS[e].field: reason for e in requested}
+                return result
             lat, lon = coords
             closest = self._closest_stations_for_zip(zipcode, lat, lon)
         else:
@@ -175,9 +181,13 @@ class WeatherLookup:
         flags: dict[str, str] = {}
         weather_types: set[str] = set()
         station = StationMeta()
+        considered = 0
+        last_distance: int | None = None
+        stopped_at_max_distance = False
 
         for station_id, distance in closest[: self.max_stations]:
             if self.max_distance_meters and distance > self.max_distance_meters:
+                stopped_at_max_distance = True
                 break
             if all(element in values for element in requested):
                 break
@@ -186,6 +196,8 @@ class WeatherLookup:
             if not station_info:
                 continue
             station_name, station_type = station_info
+            considered += 1
+            last_distance = distance
 
             if self.include_weather_types:
                 weather_types |= self._station_weather_types(
@@ -213,6 +225,16 @@ class WeatherLookup:
                     station_distance_meters=distance,
                 )
 
+        still_missing = [e for e in requested if e not in values]
+        if still_missing:
+            logger.debug(
+                "%s on %s: no value for %s after examining %d station(s)",
+                zipcode or f"{lat:.3f},{lon:.3f}",
+                target_date.strftime("%Y-%m-%d"),
+                ",".join(still_missing),
+                considered,
+            )
+
         result = assemble_result(
             target_date=target_date,
             metric_values=values,
@@ -228,7 +250,67 @@ class WeatherLookup:
             result.flags = {ELEMENTS[e].field: f for e, f in flags.items()}
         if self.include_weather_types:
             result.weather_types = weather_types
+        if self.explain:
+            result.stations_considered = considered
+            result.missing = self._missing_reasons(
+                requested,
+                values,
+                target_date,
+                considered,
+                last_distance,
+                stopped_at_max_distance,
+            )
         return result
+
+    def _missing_reasons(
+        self,
+        requested: list[str],
+        values: dict[str, float],
+        target_date: date,
+        considered: int,
+        last_distance: int | None,
+        stopped_at_max_distance: bool,
+    ) -> dict[str, str]:
+        """Explain, per requested field, why no value was found.
+
+        Args:
+            requested: Element codes that were asked for.
+            values: Element codes that were resolved to a value.
+            target_date: The queried date (named in each reason).
+            considered: Stations examined during the walk.
+            last_distance: Distance of the farthest station examined.
+            stopped_at_max_distance: Whether the walk halted at the
+                max_distance_meters limit.
+
+        Returns:
+            Field name -> reason string for each requested element with
+            no value; empty when everything requested was found.
+        """
+        missing = [e for e in requested if e not in values]
+        if not missing:
+            return {}
+
+        if considered == 0:
+            summary = "no weather stations were found near this location"
+        elif stopped_at_max_distance and self.max_distance_meters:
+            summary = (
+                f"no station within the {self.max_distance_meters / 1000:.0f} km limit"
+            )
+        else:
+            span = (
+                f" (out to {last_distance / 1000:.0f} km)"
+                if last_distance is not None
+                else ""
+            )
+            summary = f"none of the {considered} nearest stations{span}"
+
+        date_str = target_date.strftime("%Y-%m-%d")
+        if considered == 0:
+            return dict.fromkeys((ELEMENTS[e].field for e in missing), summary)
+        return {
+            ELEMENTS[e].field: f"{summary} reported {ELEMENTS[e].field} on {date_str}"
+            for e in missing
+        }
 
     def _interpolate(
         self,

--- a/src/get_weather_data/weather/online.py
+++ b/src/get_weather_data/weather/online.py
@@ -25,6 +25,7 @@ from get_weather_data.weather.results import (
     assemble_result,
 )
 from get_weather_data.weather.units import (
+    ELEMENTS,
     Units,
     ghcn_raw_to_metric,
     normalize_elements,
@@ -53,6 +54,7 @@ class OnlineLookup:
     client: NOAAClient = field(default_factory=NOAAClient)
     units: Units = "metric"
     include_weather_types: bool = False
+    explain: bool = False
     # Dense CoCoRaHS networks (precip/snow-only community observers) can
     # fill the nearest ranks in a metro, crowding out the airport station
     # that carries temperature; keep the search wide enough to reach it.
@@ -118,23 +120,35 @@ class OnlineLookup:
         else:
             coords = parsed
 
-        def _empty(day_offset: int) -> WeatherResult:
-            return WeatherResult(
+        def _empty(day_offset: int, reason: str) -> WeatherResult:
+            result = WeatherResult(
                 date=start_date + timedelta(days=day_offset),
                 zipcode=zipcode,
                 latitude=coords[0] if coords else None,
                 longitude=coords[1] if coords else None,
                 units=self.units,
             )
+            if self.explain:
+                result.stations_considered = 0
+                result.missing = {ELEMENTS[e].field: reason for e in requested}
+            return result
 
         n_days = (end_date - start_date).days + 1
         if coords is None:
-            return [_empty(i) for i in range(n_days)]
+            reason = (
+                f"ZIP code {zipcode} could not be resolved to coordinates"
+                if zipcode
+                else "the location could not be resolved to coordinates"
+            )
+            return [_empty(i, reason) for i in range(n_days)]
 
         lat, lon = coords
         stations = self._closest_stations(lat, lon, start_date, end_date)
         if not stations:
-            return [_empty(i) for i in range(n_days)]
+            return [
+                _empty(i, "no CDO stations were found near this location")
+                for i in range(n_days)
+            ]
 
         station_ids = [info.id for info, _ in stations]
         records: list[dict[str, Any]] = []
@@ -273,7 +287,46 @@ class OnlineLookup:
         )
         if self.include_weather_types:
             result.weather_types = weather_types
+        if self.explain:
+            result.stations_considered = len(stations)
+            result.missing = self._missing_reasons(
+                requested, values, target_date, len(stations)
+            )
         return result
+
+    def _missing_reasons(
+        self,
+        requested: list[str],
+        values: dict[str, float],
+        target_date: date,
+        n_stations: int,
+    ) -> dict[str, str]:
+        """Explain, per requested field, why the CDO query returned none.
+
+        Args:
+            requested: Element codes that were asked for.
+            values: Element codes resolved to a value.
+            target_date: The queried date (named in each reason).
+            n_stations: CDO stations searched near the point.
+
+        Returns:
+            Field name -> reason for each requested element with no
+            value; empty when everything requested was found.
+        """
+        missing = [e for e in requested if e not in values]
+        if not missing:
+            return {}
+        date_str = target_date.strftime("%Y-%m-%d")
+        if n_stations == 0:
+            summary = "no CDO stations were found near this location"
+            return dict.fromkeys((ELEMENTS[e].field for e in missing), summary)
+        return {
+            ELEMENTS[e].field: (
+                f"none of the {n_stations} CDO stations near this point "
+                f"reported {ELEMENTS[e].field} on {date_str}"
+            )
+            for e in missing
+        }
 
 
 def _record_date(record: dict[str, Any]) -> date | None:

--- a/src/get_weather_data/weather/results.py
+++ b/src/get_weather_data/weather/results.py
@@ -45,6 +45,11 @@ class WeatherResult:
             (GHCN stations only).
         weather_types: Present-weather phenomena for the day (e.g.
             {"fog", "thunder"}), when include_weather_types is set.
+        stations_considered: How many stations were examined to build
+            this result, when explain is set.
+        missing: Per-field reason a requested value is absent (e.g.
+            {"tmax": "none of the 20 nearest stations ..."}), when
+            explain is set; empty when every requested field was found.
     """
 
     date: date_type
@@ -71,6 +76,8 @@ class WeatherResult:
     visibility: float | None = None
     flags: dict[str, str] | None = None
     weather_types: set[str] | None = None
+    stations_considered: int | None = None
+    missing: dict[str, str] | None = None
 
 
 @dataclass

--- a/tests/test_e2e_live.py
+++ b/tests/test_e2e_live.py
@@ -117,3 +117,16 @@ def test_weather_types_off_by_default():
     """Without the flag, weather_types stays None."""
     r = _online().get("11430", date(2023, 7, 16))
     assert r.weather_types is None
+
+
+@online_only
+def test_explain_reports_provenance():
+    """explain=True attaches a station count and per-field reasons."""
+    w = Weather(online=True, explain=True)
+    r = w.get("10001", date(2023, 7, 15))
+    assert r.stations_considered is not None
+    assert r.stations_considered > 0
+    assert r.missing is not None  # a dict (possibly empty when all found)
+    # Any missing field must carry a non-empty reason string.
+    for reason in r.missing.values():
+        assert reason

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,144 @@
+"""Tests for explain=True missing-data provenance."""
+
+from datetime import date
+
+import pytest
+
+from get_weather_data.core.database import INDEX_VERSION, Database
+from get_weather_data.core.distance import Station
+from get_weather_data.weather import lookup as lookup_module
+from get_weather_data.weather.lookup import WeatherLookup
+from get_weather_data.weather.online import OnlineLookup
+
+DAY = date(2022, 1, 1)
+
+
+@pytest.fixture
+def city_db(tmp_path) -> Database:
+    db = Database(tmp_path / "city.sqlite")
+    db.init_schema()
+    db.insert_zipcode("10001", "New York", "NY", 40.7484, -73.9967)
+    db.insert_station(
+        Station(id="S1", name="PRECIP ONLY", lat=40.78, lon=-73.97, type="GHCND")
+    )
+    db.set_closest_stations_bulk({"10001": [("S1", 4000)]})
+    db.set_meta("index_version", str(INDEX_VERSION))
+    return db
+
+
+class TestStationProvenance:
+    def test_off_by_default(self, city_db, monkeypatch):
+        monkeypatch.setattr(lookup_module, "get_ghcn_data", lambda s, d: {"PRCP": 0.0})
+        r = WeatherLookup(db=city_db, use_cache=False).get_weather("10001", DAY)
+        assert r.stations_considered is None
+        assert r.missing is None
+
+    def test_missing_field_explained(self, city_db, monkeypatch):
+        # Station reports only precipitation; temperature is unexplained None.
+        monkeypatch.setattr(lookup_module, "get_ghcn_data", lambda s, d: {"PRCP": 0.0})
+        r = WeatherLookup(db=city_db, use_cache=False, explain=True).get_weather(
+            "10001", DAY
+        )
+        assert r.tmax is None
+        assert r.stations_considered == 1
+        assert "tmax" in r.missing
+        assert "2022-01-01" in r.missing["tmax"]
+        # A field that WAS found must not appear in missing.
+        assert "prcp" not in r.missing
+
+    def test_all_found_empty_missing(self, city_db, monkeypatch):
+        full = dict.fromkeys(("TMAX", "TMIN", "TAVG", "PRCP", "SNOW", "SNWD"), 0.0)
+        monkeypatch.setattr(lookup_module, "get_ghcn_data", lambda s, d: full)
+        r = WeatherLookup(db=city_db, use_cache=False, explain=True).get_weather(
+            "10001", DAY, elements=["TMAX", "PRCP"]
+        )
+        assert r.missing == {}
+        assert r.stations_considered == 1
+
+    def test_max_distance_reason(self, city_db, monkeypatch):
+        monkeypatch.setattr(lookup_module, "get_ghcn_data", lambda s, d: {"PRCP": 0.0})
+        # The only station (4 km) is past a 1 km cap -> zero considered.
+        r = WeatherLookup(
+            db=city_db,
+            use_cache=False,
+            explain=True,
+            max_distance_meters=1000,
+        ).get_weather("10001", DAY)
+        assert r.stations_considered == 0
+        assert "no weather stations" in r.missing["tmax"]
+
+    def test_unknown_zip_reason(self, city_db):
+        r = WeatherLookup(db=city_db, use_cache=False, explain=True).get_weather(
+            "00000", DAY
+        )
+        assert r.stations_considered == 0
+        assert "not in the station database" in r.missing["tmax"]
+
+
+class TestOnlineProvenance:
+    def _online(self, **kwargs) -> OnlineLookup:
+        from get_weather_data.api.noaa import NOAAClient
+
+        kwargs.setdefault("client", NOAAClient(token="test"))
+        return OnlineLookup(**kwargs)
+
+    def _stations(self):
+        from get_weather_data.api.noaa import StationInfo
+
+        return [(StationInfo(id="S1", name="A", latitude=40.0, longitude=-73.0), 100)]
+
+    def test_missing_field_explained(self):
+        records = [
+            {
+                "date": "2022-01-01T00:00:00",
+                "datatype": "PRCP",
+                "station": "S1",
+                "value": 0.0,
+            }
+        ]
+        online = self._online(explain=True)
+        r = online._build_result(
+            DAY, records, self._stations(), ["TMAX", "PRCP"], None, 40.0, -73.0
+        )
+        assert r.stations_considered == 1
+        assert "tmax" in r.missing
+        assert "prcp" not in r.missing
+
+    def test_off_by_default(self):
+        online = self._online()
+        r = online._build_result(DAY, [], self._stations(), ["TMAX"], None, 40.0, -73.0)
+        assert r.stations_considered is None
+        assert r.missing is None
+
+
+class TestOutputColumns:
+    def test_frame_provenance_columns(self):
+        pytest.importorskip("pandas")
+        from get_weather_data.weather.frame import results_to_frame
+        from get_weather_data.weather.results import WeatherResult
+
+        plain = results_to_frame([WeatherResult(date=DAY)])
+        assert "stations_considered" not in plain.columns
+
+        explained = results_to_frame(
+            [
+                WeatherResult(
+                    date=DAY,
+                    stations_considered=3,
+                    missing={"tmax": "none of the 3 nearest stations ..."},
+                )
+            ]
+        )
+        assert explained["stations_considered"].iloc[0] == 3
+        assert "tmax:" in explained["missing"].iloc[0]
+
+    def test_batch_columns(self):
+        from get_weather_data.weather.batch import _format_missing, _weather_columns
+
+        cols = _weather_columns(False, explain=True)
+        assert "stations_considered" in cols
+        assert cols.index("missing") == cols.index("weather_error") - 1
+        assert "stations_considered" not in _weather_columns(False, explain=False)
+
+        assert _format_missing(None) == ""
+        assert _format_missing({"tmax": "no station"}) == "tmax: no station"


### PR DESCRIPTION
## Summary

Phase 2.5 — make missing values *explainable*. A blank `tmax` used to be silent; now the package can tell you why.

- `Weather(explain=True)` populates `result.stations_considered` and `result.missing` — a per-field reason each requested value is absent (station coverage / distance cap / unknown ZIP / no CDO stations near the point), on **both** the station and online backends.
- Surfaced everywhere: `get --explain` (prints the reasons), `process --explain` (adds `stations_considered` + `missing` CSV columns), and `get_frame(...)` (adds the columns when present).
- A `debug`-level log line names the fields still missing after the station walk, for `verbose=True` diagnosis.

This directly addresses the Buffalo-class failure from the earlier live audit — precip-only community observers crowding out the airport temperature station produced a silent `None`; with `explain=True` that gap now carries `"none of the N nearest stations (out to X km) reported tmax on ..."`.

## Verification

- Full local gate green: ruff, ruff format, pyright (0 errors), pydoclint, `sphinx -W`, `pytest --cov` **223 passed / 89.75%** (floor 85).
- New `tests/test_provenance.py` (9 tests): station + online reasons, found fields excluded from `missing`, distance-cap and unknown-ZIP paths, frame/batch columns.
- Live-audited: a live `-m live` E2E asserts `stations_considered > 0` and every `missing` reason is non-empty against the real CDO API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)