### PR TITLE
Hourly data via ISD-Lite (v6.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Notable changes to get-weather-data. Versions follow the git tags.
 
+## 6.0.0
+
+Added
+
+- Hourly data via NOAA ISD-Lite: `Weather.get_hourly(location, start,
+  end)` returns one `HourlyResult` per hour (temp, dewpoint,
+  sea-level pressure, wind direction/speed, sky code, 1h/6h precip) at
+  the nearest USAF-WBAN station; `get_hourly_frame(...)` for pandas and
+  `get-weather hourly ...` on the CLI. Timestamps are UTC.
+- New public `HourlyResult` type and `weather/isd.py` reader.
+
+This is a major version because it adds a new result type and API
+surface; the daily API is unchanged. Hourly needs the local database
+(there is no online/CDO equivalent for ISD-Lite).
+
 ## 5.3.0
 
 Added

--- a/README.md
+++ b/README.md
@@ -208,6 +208,28 @@ print(cov.station_name, cov.station_distance_meters, "m away")
 print(f"tmax present on {cov.fraction('tmax'):.0%} of days")
 ```
 
+### Hourly data
+
+For sub-daily detail, `get_hourly(...)` returns one `HourlyResult` per
+hour from NOAA's ISD-Lite (nearest airport/USAF-WBAN station).
+**Timestamps are UTC** and the local station database is required
+(`setup()`); there is no online equivalent.
+
+```python
+weather = Weather(units="imperial")
+
+hours = weather.get_hourly("11371", "2023-07-16")  # LaGuardia, one UTC day
+for h in hours[:3]:
+    print(h.observed_at, h.temp, "F", h.wind_speed, "mph", h.wind_direction, "deg")
+
+# pandas: one row per hour (needs the [pandas] extra)
+df = weather.get_hourly_frame("11371", "2023-07-16", "2023-07-17")
+```
+
+CLI: `get-weather hourly 11371 2023-07-16 [--end 2023-07-17] [--units imperial]`.
+Fields: `temp`, `dewpoint`, `sea_level_pressure`, `wind_direction`
+(degrees), `wind_speed`, `sky_condition`, `precip_1h`, `precip_6h`.
+
 ## Weather Variables
 
 All values are floats in the units below (or their imperial

--- a/src/get_weather_data/__init__.py
+++ b/src/get_weather_data/__init__.py
@@ -25,7 +25,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from get_weather_data.main import Weather
 from get_weather_data.weather.location import LocationInput
-from get_weather_data.weather.results import Coverage, WeatherResult
+from get_weather_data.weather.results import Coverage, HourlyResult, WeatherResult
 from get_weather_data.weather.units import Units
 
 # Library hygiene: attach a NullHandler so importing the package never
@@ -39,6 +39,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "Coverage",
+    "HourlyResult",
     "LocationInput",
     "Units",
     "Weather",

--- a/src/get_weather_data/cli.py
+++ b/src/get_weather_data/cli.py
@@ -188,6 +188,77 @@ def get(
 
 
 @cli.command()
+@click.argument("location")
+@click.argument("target_date")
+@click.option("--end", "end_date", help="End date YYYY-MM-DD (default: single day)")
+@click.option(
+    "--units",
+    type=click.Choice(["metric", "imperial"]),
+    default="metric",
+    help="Unit system for the values shown",
+)
+@click.pass_context
+def hourly(
+    ctx: click.Context,
+    location: str,
+    target_date: str,
+    end_date: str | None,
+    units: str,
+) -> None:
+    """Get hourly weather (ISD-Lite) for a location and date.
+
+    LOCATION: 5-digit US ZIP code or "lat,lon" coordinates.
+
+    TARGET_DATE: UTC date in YYYY-MM-DD format. Times shown are UTC.
+    Requires the local database (run 'get-weather setup' first).
+    """
+    try:
+        weather = Weather(
+            database_path=ctx.obj["database"],
+            verbose=ctx.obj["verbose"],
+            units=units,  # type: ignore[arg-type]
+        )
+        results = weather.get_hourly(location, target_date, end_date)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+    if not results:
+        console.print("[yellow]No hourly data found near this location.[/yellow]")
+        return
+
+    temp_label = unit_label("TMAX", results[0].units)
+    wind_label = "mph" if results[0].units == "imperial" else "m/s"
+    table = Table(title=f"Hourly weather for {location} (UTC)")
+    table.add_column("Time (UTC)", style="cyan")
+    table.add_column(f"Temp ({temp_label})", justify="right")
+    table.add_column(f"Dewpt ({temp_label})", justify="right")
+    table.add_column(f"Wind ({wind_label})", justify="right")
+    table.add_column("Dir", justify="right")
+
+    def _fmt(value: float | int | None, digits: int = 1) -> str:
+        return (
+            f"{value:.{digits}f}"
+            if isinstance(value, float)
+            else (str(value) if value is not None else "—")
+        )
+
+    for r in results:
+        table.add_row(
+            r.observed_at.strftime("%Y-%m-%d %H:%M"),
+            _fmt(r.temp),
+            _fmt(r.dewpoint),
+            _fmt(r.wind_speed),
+            _fmt(r.wind_direction),
+        )
+    console.print(table)
+    station = results[0]
+    console.print(
+        f"Station: {station.station_name} ({station.station_distance_meters:,} m away)"
+    )
+
+
+@cli.command()
 @click.argument("input_file", type=click.Path(exists=True))
 @click.argument("output_file", type=click.Path())
 @click.option("--zip-column", default="zip", help="ZIP code column name or index")

--- a/src/get_weather_data/main.py
+++ b/src/get_weather_data/main.py
@@ -17,11 +17,13 @@ from get_weather_data.stations import (
 )
 from get_weather_data.weather.batch import process_csv as _process_csv
 from get_weather_data.weather.gridded import GriddedLookup
+from get_weather_data.weather.hourly import HourlyLookup
 from get_weather_data.weather.location import LocationInput
 from get_weather_data.weather.lookup import WeatherLookup
 from get_weather_data.weather.online import OnlineLookup
 from get_weather_data.weather.results import (
     Coverage,
+    HourlyResult,
     WeatherResult,
     summarize_coverage,
 )
@@ -70,6 +72,7 @@ class Weather:
     _lookup: WeatherLookup | None = field(default=None, repr=False)
     _online_lookup: OnlineLookup | None = field(default=None, repr=False)
     _grid: GriddedLookup | None = field(default=None, repr=False)
+    _hourly: HourlyLookup | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         """Configure logging and build the selected lookup backend.
@@ -120,6 +123,13 @@ class Weather:
         if self._grid is None:
             self._grid = GriddedLookup(units=self.units)
         return self._grid
+
+    @property
+    def hourly(self) -> HourlyLookup:
+        """Get the ISD-Lite hourly-lookup instance."""
+        if self._hourly is None:
+            self._hourly = HourlyLookup(db=self.db, units=self.units)
+        return self._hourly
 
     def setup(
         self,
@@ -283,6 +293,69 @@ class Weather:
             end_date = start_date
         results = self.get_range(location, start_date, end_date, elements)
         return results_to_frame(results)
+
+    def get_hourly(
+        self,
+        location: LocationInput,
+        start_date: str | date,
+        end_date: str | date | None = None,
+    ) -> list[HourlyResult]:
+        """Get hourly observations for a location (ISD-Lite).
+
+        Resolves the nearest USAF-WBAN station and reads hourly ISD-Lite
+        data. Requires the local database (``setup()``); there is no
+        online equivalent for hourly data.
+
+        Args:
+            location: 5-digit US ZIP code, "lat,lon" string, or
+                (lat, lon) tuple.
+            start_date: First UTC date (YYYY-MM-DD) or date object.
+            end_date: Last UTC date; defaults to start_date (single day).
+
+        Returns:
+            One HourlyResult per available hour, in time order (UTC).
+
+        Raises:
+            ValueError: If this Weather was created with online=True.
+        """
+        if self.online:
+            raise ValueError(
+                "get_hourly requires the local database (run setup()); "
+                "hourly ISD-Lite is not served by the online CDO API."
+            )
+        if isinstance(start_date, str):
+            start_date = date.fromisoformat(start_date)
+        if isinstance(end_date, str):
+            end_date = date.fromisoformat(end_date)
+        return self.hourly.get_hourly(location, start_date, end_date)
+
+    def get_hourly_frame(
+        self,
+        location: LocationInput,
+        start_date: str | date,
+        end_date: str | date | None = None,
+    ) -> "pd.DataFrame":
+        """Get hourly observations as a pandas DataFrame.
+
+        One row per hour, metadata columns followed by the value columns
+        (in the configured units). Requires the ``pandas`` extra.
+
+        Args:
+            location: 5-digit US ZIP code, "lat,lon" string, or
+                (lat, lon) tuple.
+            start_date: First UTC date (YYYY-MM-DD) or date object.
+            end_date: Last UTC date; defaults to start_date (single day).
+
+        Returns:
+            A tidy DataFrame of the hourly results.
+
+        Raises:
+            ImportError: If pandas is not installed.
+        """  # noqa: DOC502 - raised by hourly_results_to_frame
+        from get_weather_data.weather.frame import hourly_results_to_frame
+
+        results = self.get_hourly(location, start_date, end_date)
+        return hourly_results_to_frame(results)
 
     def coverage(
         self,

--- a/src/get_weather_data/weather/frame.py
+++ b/src/get_weather_data/weather/frame.py
@@ -7,7 +7,7 @@ Imports are deferred so the base package stays pandas-free.
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from get_weather_data.weather.results import WeatherResult
+from get_weather_data.weather.results import HourlyResult, WeatherResult
 from get_weather_data.weather.units import ELEMENTS
 from get_weather_data.weather.weather_types import format_weather_types
 
@@ -118,3 +118,52 @@ def result_to_frame(result: WeatherResult) -> "pd.DataFrame":
         ImportError: If pandas is not installed.
     """  # noqa: DOC502 - raised by results_to_frame
     return results_to_frame([result])
+
+
+# Hourly output columns, in order: metadata then values.
+_HOURLY_META = [
+    "observed_at",
+    "zipcode",
+    "latitude",
+    "longitude",
+    "station_id",
+    "station_name",
+    "station_distance_meters",
+    "units",
+]
+_HOURLY_VALUES = [
+    "temp",
+    "dewpoint",
+    "sea_level_pressure",
+    "wind_direction",
+    "wind_speed",
+    "sky_condition",
+    "precip_1h",
+    "precip_6h",
+]
+
+
+def hourly_results_to_frame(results: Sequence[HourlyResult]) -> "pd.DataFrame":
+    """Convert hourly results to a tidy DataFrame.
+
+    One row per hour, metadata columns followed by the value columns.
+    The ``observed_at`` column is a UTC-aware datetime.
+
+    Args:
+        results: Hourly results, e.g. from ``Weather.get_hourly``.
+
+    Returns:
+        A DataFrame with a stable column schema even when empty; value
+        columns carry the results' units.
+
+    Raises:
+        ImportError: If pandas is not installed.
+    """  # noqa: DOC502 - raised by _require_pandas
+    pd = _require_pandas()
+    columns = _HOURLY_META + _HOURLY_VALUES
+    rows = [
+        {column: getattr(result, column) for column in columns} for result in results
+    ]
+    frame = pd.DataFrame(rows, columns=columns)
+    frame["observed_at"] = pd.to_datetime(frame["observed_at"], utc=True)
+    return frame

--- a/src/get_weather_data/weather/hourly.py
+++ b/src/get_weather_data/weather/hourly.py
@@ -1,0 +1,161 @@
+"""Hourly weather lookup backed by ISD-Lite and the local station DB.
+
+Resolves a location to the nearest USAF-WBAN (ISD) station using the
+same station database as the daily path, then reads hourly observations
+from ISD-Lite. Station selection needs the local database (``setup()``);
+there is no online (CDO) equivalent for hourly data.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+
+from get_weather_data.core.database import Database
+from get_weather_data.core.distance import find_closest
+from get_weather_data.weather.isd import get_isd_hourly
+from get_weather_data.weather.location import LocationInput, parse_location
+from get_weather_data.weather.results import HourlyResult
+from get_weather_data.weather.units import (
+    HPA_TO_INHG,
+    IN_TO_MM,
+    MS_TO_MPH,
+    Units,
+)
+
+logger = logging.getLogger("get_weather_data")
+
+# Nearest USAF-WBAN stations to try before giving up (many stations have
+# a GSOD daily record but no ISD-Lite file for a given year).
+_MAX_STATIONS = 5
+
+
+def _to_units(value: float | None, units: Units, factor: float) -> float | None:
+    """Scale a metric value to the requested unit system."""
+    if value is None:
+        return None
+    return value if units == "metric" else value * factor
+
+
+def _c_to_f(celsius: float | None, units: Units) -> float | None:
+    """Convert °C to the requested unit system."""
+    if celsius is None:
+        return None
+    return celsius if units == "metric" else celsius * 9 / 5 + 32
+
+
+@dataclass
+class HourlyLookup:
+    """Look up hourly weather via ISD-Lite and the local station DB."""
+
+    db: Database = field(default_factory=Database)
+    units: Units = "metric"
+    max_stations: int = _MAX_STATIONS
+
+    def get_hourly(
+        self,
+        location: LocationInput,
+        start_date: date,
+        end_date: date | None = None,
+    ) -> list[HourlyResult]:
+        """Get hourly observations for a location over a date range.
+
+        Args:
+            location: 5-digit US ZIP code, "lat,lon" string, or
+                (lat, lon) tuple.
+            start_date: First UTC date (inclusive).
+            end_date: Last UTC date (inclusive); defaults to start_date.
+
+        Returns:
+            One HourlyResult per available hour across the range, in
+            time order. Empty when no nearby ISD station has data.
+
+        Raises:
+            ValueError: If the location cannot be parsed.
+        """  # noqa: DOC502 - raised by parse_location
+        if end_date is None:
+            end_date = start_date
+
+        coords, zipcode = self._resolve(location)
+        if coords is None:
+            return []
+        lat, lon = coords
+
+        dates = _date_range(start_date, end_date)
+        for station in self._nearest_stations(lat, lon):
+            station_id, station_name, distance = station
+            records: list[dict[str, float | int | datetime | None]] = []
+            for day in dates:
+                records.extend(get_isd_hourly(station_id, day))
+            if records:
+                return [
+                    self._build(
+                        r, zipcode, lat, lon, station_id, station_name, distance
+                    )
+                    for r in records
+                ]
+
+        logger.debug(
+            "No ISD-Lite data near %s for %s..%s",
+            zipcode or f"{lat:.3f},{lon:.3f}",
+            start_date,
+            end_date,
+        )
+        return []
+
+    def _resolve(
+        self, location: LocationInput
+    ) -> tuple[tuple[float, float] | None, str | None]:
+        """Resolve a location to coordinates and (if any) its ZIP code."""
+        parsed = parse_location(location)
+        if isinstance(parsed, str):
+            coords = self.db.get_zipcode(parsed)
+            if coords is None:
+                logger.warning("ZIP code %s not found in database", parsed)
+            return coords, parsed
+        return parsed, None
+
+    def _nearest_stations(self, lat: float, lon: float) -> list[tuple[str, str, int]]:
+        """Nearest USAF-WBAN stations as (id, name, distance_meters)."""
+        stations = self.db.get_stations(station_type="USAF-WBAN")
+        closest = find_closest(lat, lon, stations, n=self.max_stations)
+        return [(sd.station.id, sd.station.name, sd.distance_meters) for sd in closest]
+
+    def _build(
+        self,
+        record: dict[str, float | int | datetime | None],
+        zipcode: str | None,
+        lat: float,
+        lon: float,
+        station_id: str,
+        station_name: str,
+        distance: int,
+    ) -> HourlyResult:
+        """Convert one metric ISD-Lite record to a HourlyResult."""
+        u = self.units
+        return HourlyResult(
+            observed_at=record["observed_at"],  # type: ignore[arg-type]
+            zipcode=zipcode,
+            latitude=lat,
+            longitude=lon,
+            station_id=station_id,
+            station_name=station_name,
+            station_distance_meters=distance,
+            units=u,
+            temp=_c_to_f(record["temp"], u),  # type: ignore[arg-type]
+            dewpoint=_c_to_f(record["dewpoint"], u),  # type: ignore[arg-type]
+            sea_level_pressure=_to_units(
+                record["sea_level_pressure"],  # type: ignore[arg-type]
+                u,
+                HPA_TO_INHG,
+            ),
+            wind_direction=record["wind_direction"],  # type: ignore[arg-type]
+            wind_speed=_to_units(record["wind_speed"], u, MS_TO_MPH),  # type: ignore[arg-type]
+            sky_condition=record["sky_condition"],  # type: ignore[arg-type]
+            precip_1h=_to_units(record["precip_1h"], u, 1 / IN_TO_MM),  # type: ignore[arg-type]
+            precip_6h=_to_units(record["precip_6h"], u, 1 / IN_TO_MM),  # type: ignore[arg-type]
+        )
+
+
+def _date_range(start: date, end: date) -> list[date]:
+    """Inclusive list of dates from start to end."""
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]

--- a/src/get_weather_data/weather/isd.py
+++ b/src/get_weather_data/weather/isd.py
@@ -1,0 +1,136 @@
+"""ISD-Lite hourly data for USAF-WBAN stations.
+
+Integrated Surface Database (ISD) Lite ships one whitespace-delimited,
+gzipped file per station-year at NCEI. Each row is one hour (UTC) with
+air temperature, dew point, sea-level pressure, wind direction and
+speed, a sky-cover code, and 1- and 6-hour precipitation. Numeric
+fields are scaled by 10 (temp ``78`` = 7.8 °C) and ``-9999`` marks a
+missing value.
+"""
+
+import gzip
+import logging
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+from get_weather_data.core.cache import is_fresh, year_is_immutable
+from get_weather_data.core.config import get_config
+from get_weather_data.core.download import download_with_retry
+
+logger = logging.getLogger("get_weather_data")
+
+ISD_LITE_URL = (
+    "https://www.ncei.noaa.gov/pub/data/noaa/isd-lite/{year}/{station_id}-{year}.gz"
+)
+
+# (column index, field name, scale). Missing = -9999. wind_direction and
+# sky_condition are unscaled integers; the rest are tenths.
+_TENTHS = 10.0
+_FIELDS: list[tuple[int, str, float]] = [
+    (4, "temp", _TENTHS),
+    (5, "dewpoint", _TENTHS),
+    (6, "sea_level_pressure", _TENTHS),
+    (7, "wind_direction", 1.0),
+    (8, "wind_speed", _TENTHS),
+    (9, "sky_condition", 1.0),
+    (10, "precip_1h", _TENTHS),
+    (11, "precip_6h", _TENTHS),
+]
+_INT_FIELDS = frozenset({"wind_direction", "sky_condition"})
+
+
+def _get_isd_file_path(station_id: str, year: int) -> Path:
+    """Path to the cached ISD-Lite file for a station-year."""
+    config = get_config()
+    return config.cache_dir / "isd" / str(year) / f"{station_id}.txt.gz"
+
+
+def _ensure_isd_file(station_id: str, year: int) -> Path | None:
+    """Download the ISD-Lite file if not cached (or stale for a live year).
+
+    Args:
+        station_id: USAF-WBAN station ID (e.g. "725030-14732").
+        year: Calendar year to ensure.
+
+    Returns:
+        Path to the cached file, or None if it could not be downloaded.
+    """
+    file_path = _get_isd_file_path(station_id, year)
+
+    if file_path.exists() and (
+        year_is_immutable(year) or is_fresh(file_path, get_config().cache_max_age_days)
+    ):
+        return file_path
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    url = ISD_LITE_URL.format(year=year, station_id=station_id)
+    return download_with_retry(url, file_path)
+
+
+def _parse_line(
+    line: str, target_date: date
+) -> dict[str, float | int | datetime | None] | None:
+    """Parse one ISD-Lite row into a metric hourly record for a date.
+
+    Args:
+        line: One whitespace-delimited ISD-Lite row.
+        target_date: Only rows on this UTC date are returned.
+
+    Returns:
+        A record dict (metric units, missing fields None) with an
+        ``observed_at`` UTC datetime, or None if the row is malformed or
+        falls on another date.
+    """
+    parts = line.split()
+    if len(parts) < 12:
+        return None
+    try:
+        year, month, day, hour = (int(parts[i]) for i in range(4))
+    except ValueError:
+        return None
+    if (year, month, day) != (target_date.year, target_date.month, target_date.day):
+        return None
+
+    record: dict[str, float | int | datetime | None] = {
+        "observed_at": datetime(year, month, day, hour, tzinfo=UTC)
+    }
+    for index, field_name, scale in _FIELDS:
+        raw = parts[index]
+        if raw == "-9999":
+            record[field_name] = None
+            continue
+        try:
+            value = int(raw) / scale
+        except ValueError:
+            record[field_name] = None
+            continue
+        record[field_name] = int(value) if field_name in _INT_FIELDS else value
+    return record
+
+
+def get_isd_hourly(
+    station_id: str, target_date: date
+) -> list[dict[str, float | int | datetime | None]]:
+    """Get one day's hourly ISD-Lite records for a station, in metric.
+
+    Args:
+        station_id: USAF-WBAN station ID (e.g. "725030-14732").
+        target_date: UTC date to read.
+
+    Returns:
+        One record dict per available hour (sorted by time), each with
+        an ``observed_at`` UTC datetime and metric values (missing
+        fields are None). Empty if the station-year file is unavailable.
+    """
+    file_path = _ensure_isd_file(station_id, target_date.year)
+    if file_path is None:
+        return []
+
+    records: list[dict[str, float | int | datetime | None]] = []
+    with gzip.open(file_path, "rt", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            record = _parse_line(line, target_date)
+            if record is not None:
+                records.append(record)
+    records.sort(key=lambda r: r["observed_at"])  # type: ignore[arg-type,return-value]
+    return records

--- a/src/get_weather_data/weather/results.py
+++ b/src/get_weather_data/weather/results.py
@@ -4,6 +4,7 @@ from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date as date_type
+from datetime import datetime
 
 from get_weather_data.weather.units import ELEMENTS, Units, convert
 
@@ -78,6 +79,53 @@ class WeatherResult:
     weather_types: set[str] | None = None
     stations_considered: int | None = None
     missing: dict[str, str] | None = None
+
+
+@dataclass
+class HourlyResult:
+    """One hour of observations at a station (ISD-Lite).
+
+    Value fields are in the unit system named by ``units``:
+    metric — temp/dewpoint in °C, sea_level_pressure in hPa, wind_speed
+    in m/s, precip in mm; imperial — °F, inHg, mph, in. wind_direction
+    is always degrees (0-360). Fields are None when the hour had no
+    reading for that variable.
+
+    Attributes:
+        observed_at: The observation time, in UTC (timezone-aware).
+        zipcode: Queried ZIP code, when the query used one.
+        latitude: Latitude of the resolved query point.
+        longitude: Longitude of the resolved query point.
+        station_id: USAF-WBAN station that supplied the hour.
+        station_name: Its human-readable name.
+        station_distance_meters: Distance from the query point.
+        units: Unit system of the value fields.
+        temp: Air temperature.
+        dewpoint: Dew point temperature.
+        sea_level_pressure: Sea-level pressure.
+        wind_direction: Wind direction in degrees (0-360; 0 = calm/north).
+        wind_speed: Wind speed.
+        sky_condition: Total sky-cover code (ISD-Lite; categorical).
+        precip_1h: Liquid precipitation over the past hour.
+        precip_6h: Liquid precipitation over the past six hours.
+    """
+
+    observed_at: datetime
+    zipcode: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    station_id: str | None = None
+    station_name: str | None = None
+    station_distance_meters: int | None = None
+    units: Units = "metric"
+    temp: float | None = None
+    dewpoint: float | None = None
+    sea_level_pressure: float | None = None
+    wind_direction: int | None = None
+    wind_speed: float | None = None
+    sky_condition: int | None = None
+    precip_1h: float | None = None
+    precip_6h: float | None = None
 
 
 @dataclass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 """Tests for CLI commands."""
 
-from datetime import date
+from datetime import UTC, date
 
 import respx
 from click.testing import CliRunner
@@ -49,6 +49,25 @@ class _FakeWeather:
         _FakeWeather.last_kwargs = kwargs
         return 3
 
+    def get_hourly(self, location, start_date, end_date=None):
+        from datetime import datetime
+
+        from get_weather_data.weather.results import HourlyResult
+
+        return [
+            HourlyResult(
+                observed_at=datetime(2023, 7, 16, 0, tzinfo=UTC),
+                station_id="725030-14732",
+                station_name="LA GUARDIA",
+                station_distance_meters=942,
+                units="metric",
+                temp=27.2,
+                dewpoint=21.0,
+                wind_speed=4.6,
+                wind_direction=170,
+            )
+        ]
+
 
 class TestCliCommands:
     def test_setup(self, monkeypatch):
@@ -68,6 +87,23 @@ class TestCliCommands:
         assert "Maximum temperature" in result.output
         # zero precip renders as a value, not N/A
         assert "0.0" in result.output
+
+    def test_hourly_table(self, monkeypatch):
+        monkeypatch.setattr(cli_module, "Weather", _FakeWeather)
+        result = CliRunner().invoke(cli, ["hourly", "11371", "2023-07-16"])
+        assert result.exit_code == 0
+        assert "LA GUARDIA" in result.output
+        assert "2023-07-16 00:00" in result.output
+
+    def test_hourly_empty(self, monkeypatch):
+        class NoData(_FakeWeather):
+            def get_hourly(self, *a, **k):
+                return []
+
+        monkeypatch.setattr(cli_module, "Weather", NoData)
+        result = CliRunner().invoke(cli, ["hourly", "11371", "2023-07-16"])
+        assert result.exit_code == 0
+        assert "No hourly data" in result.output
 
     def test_get_error(self, monkeypatch):
         class Boom(_FakeWeather):

--- a/tests/test_e2e_live.py
+++ b/tests/test_e2e_live.py
@@ -119,6 +119,22 @@ def test_weather_types_off_by_default():
     assert r.weather_types is None
 
 
+def test_hourly_traces_a_day():
+    """ISD-Lite hourly for a well-instrumented airport traces a full day."""
+    w = Weather(units="imperial")  # local DB; hourly needs setup()
+    if not w.db.exists():
+        pytest.skip("no local station database")
+    results = w.get_hourly("11371", date(2023, 7, 16))  # LaGuardia
+    if not results:
+        pytest.skip("no ISD-Lite data for this station/date")
+    assert 20 <= len(results) <= 24  # a near-complete UTC day
+    assert results == sorted(results, key=lambda r: r.observed_at)
+    temps = [r.temp for r in results if r.temp is not None]
+    assert temps  # some temperature readings
+    assert all(-40.0 <= t <= 130.0 for t in temps)  # plausible °F
+    assert results[0].observed_at.tzinfo is not None  # UTC-aware
+
+
 @online_only
 def test_explain_reports_provenance():
     """explain=True attaches a station count and per-field reasons."""

--- a/tests/test_hourly.py
+++ b/tests/test_hourly.py
@@ -1,0 +1,213 @@
+"""Tests for hourly ISD-Lite parsing, lookup, and output."""
+
+import gzip
+from datetime import UTC, date, datetime
+
+import pytest
+import respx
+from httpx import Response
+
+from get_weather_data.core.database import INDEX_VERSION, Database
+from get_weather_data.core.distance import Station
+from get_weather_data.weather import hourly as hourly_module
+from get_weather_data.weather import isd as isd_module
+from get_weather_data.weather.hourly import HourlyLookup
+from get_weather_data.weather.isd import _parse_line, get_isd_hourly
+from get_weather_data.weather.results import HourlyResult
+
+DAY = date(2023, 1, 1)
+
+# Real ISD-Lite rows (LaGuardia 2023): year mo dy hr temp dewp slp dir spd sky p1 p6
+SAMPLE = (
+    "2023 01 01 00    78    72 10098    70    15     9     8 -9999\n"
+    "2023 01 01 01    83    72 10086     0     0     9    13 -9999\n"
+    "2023 01 01 02   122   111 -9999   240    31 -9999 -9999 -9999\n"
+    "2023 01 02 00    61   -44 10153   330    46 -9999     0 -9999\n"
+)
+
+
+class TestParseLine:
+    def test_scaling_and_fields(self):
+        r = _parse_line(
+            "2023 01 01 00    78    72 10098    70    15     9     8 5", DAY
+        )
+        assert r is not None
+        assert r["observed_at"] == datetime(2023, 1, 1, 0, tzinfo=UTC)
+        assert r["temp"] == pytest.approx(7.8)
+        assert r["dewpoint"] == pytest.approx(7.2)
+        assert r["sea_level_pressure"] == pytest.approx(1009.8)
+        assert r["wind_direction"] == 70  # unscaled int
+        assert r["wind_speed"] == pytest.approx(1.5)
+        assert r["sky_condition"] == 9  # unscaled int
+        assert r["precip_1h"] == pytest.approx(0.8)
+        assert r["precip_6h"] == pytest.approx(0.5)
+
+    def test_missing_sentinel(self):
+        r = _parse_line(
+            "2023 01 01 02   122   111 -9999   240    31 -9999 -9999 -9999", DAY
+        )
+        assert r is not None
+        assert r["sea_level_pressure"] is None
+        assert r["sky_condition"] is None
+        assert r["precip_1h"] is None
+        assert r["temp"] == pytest.approx(12.2)
+
+    def test_other_date_skipped(self):
+        assert _parse_line("2023 01 02 00    61   -44 10153 330 46 0 0 0", DAY) is None
+
+    def test_malformed_skipped(self):
+        assert _parse_line("garbage row", DAY) is None
+        assert _parse_line("2023 01 01", DAY) is None
+
+
+class TestGetIsdHourly:
+    @pytest.fixture
+    def isd_file(self, tmp_path, monkeypatch):
+        path = tmp_path / "725030-14732.txt.gz"
+        path.write_bytes(gzip.compress(SAMPLE.encode()))
+        monkeypatch.setattr(isd_module, "_ensure_isd_file", lambda sid, yr: path)
+        return path
+
+    def test_returns_day_sorted(self, isd_file):
+        rows = get_isd_hourly("725030-14732", DAY)
+        assert len(rows) == 3  # three rows on 2023-01-01, one on 01-02 excluded
+        hours = [r["observed_at"].hour for r in rows]
+        assert hours == [0, 1, 2]
+
+    def test_missing_file_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(isd_module, "_ensure_isd_file", lambda sid, yr: None)
+        assert get_isd_hourly("725030-14732", DAY) == []
+
+
+class TestEnsureIsdFile:
+    @pytest.fixture(autouse=True)
+    def _isolated(self, tmp_path, monkeypatch):
+        from get_weather_data.core.config import Config, set_config
+
+        set_config(Config(ncdc_token=None, data_dir=tmp_path, cache_dir=tmp_path))
+
+    @respx.mock
+    def test_downloads_then_caches(self):
+        url = isd_module.ISD_LITE_URL.format(year=2023, station_id="725030-14732")
+        route = respx.get(url).mock(
+            return_value=Response(200, content=gzip.compress(SAMPLE.encode()))
+        )
+        first = isd_module._ensure_isd_file("725030-14732", 2023)
+        assert first is not None
+        # A historical year is immutable: the cache hit skips a second GET.
+        second = isd_module._ensure_isd_file("725030-14732", 2023)
+        assert second == first
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_missing_file_returns_none(self):
+        url = isd_module.ISD_LITE_URL.format(year=2023, station_id="000000-00000")
+        respx.get(url).mock(return_value=Response(404))
+        assert isd_module._ensure_isd_file("000000-00000", 2023) is None
+
+
+@pytest.fixture
+def city_db(tmp_path) -> Database:
+    db = Database(tmp_path / "city.sqlite")
+    db.init_schema()
+    db.insert_zipcode("11371", "New York", "NY", 40.7747, -73.8724)
+    db.insert_station(
+        Station(
+            id="725030-14732",
+            name="LA GUARDIA",
+            lat=40.779,
+            lon=-73.88,
+            type="USAF-WBAN",
+        )
+    )
+    db.set_meta("index_version", str(INDEX_VERSION))
+    return db
+
+
+def _canned(sid, day):
+    return [
+        {
+            "observed_at": datetime(day.year, day.month, day.day, 0, tzinfo=UTC),
+            "temp": 10.0,
+            "dewpoint": 5.0,
+            "sea_level_pressure": 1013.0,
+            "wind_direction": 180,
+            "wind_speed": 5.0,
+            "sky_condition": 4,
+            "precip_1h": 2.54,
+            "precip_6h": None,
+        }
+    ]
+
+
+class TestHourlyLookup:
+    def test_metric_passthrough(self, city_db, monkeypatch):
+        monkeypatch.setattr(hourly_module, "get_isd_hourly", _canned)
+        res = HourlyLookup(db=city_db).get_hourly("11371", DAY)
+        assert len(res) == 1
+        r = res[0]
+        assert r.temp == pytest.approx(10.0)
+        assert r.station_id == "725030-14732"
+        assert r.station_distance_meters is not None
+        assert r.precip_1h == pytest.approx(2.54)
+
+    def test_imperial_conversion(self, city_db, monkeypatch):
+        monkeypatch.setattr(hourly_module, "get_isd_hourly", _canned)
+        res = HourlyLookup(db=city_db, units="imperial").get_hourly("11371", DAY)
+        r = res[0]
+        assert r.temp == pytest.approx(50.0)  # 10 C -> 50 F
+        assert r.wind_speed == pytest.approx(5.0 * 2.2369362920544)
+        assert r.precip_1h == pytest.approx(2.54 / 25.4)  # 2.54 mm -> 0.1 in
+        assert r.wind_direction == 180  # unchanged
+
+    def test_station_walk_skips_empty(self, city_db, monkeypatch):
+        # First (only) station returns nothing -> overall empty, no crash.
+        monkeypatch.setattr(hourly_module, "get_isd_hourly", lambda sid, day: [])
+        assert HourlyLookup(db=city_db).get_hourly("11371", DAY) == []
+
+    def test_unknown_zip_empty(self, city_db, monkeypatch):
+        monkeypatch.setattr(hourly_module, "get_isd_hourly", _canned)
+        assert HourlyLookup(db=city_db).get_hourly("00000", DAY) == []
+
+    def test_date_range(self, city_db, monkeypatch):
+        monkeypatch.setattr(hourly_module, "get_isd_hourly", _canned)
+        res = HourlyLookup(db=city_db).get_hourly("11371", DAY, date(2023, 1, 3))
+        assert len(res) == 3  # one canned hour per day, 3 days
+
+
+class TestFacadeGuard:
+    def test_online_mode_rejects_hourly(self, tmp_path, monkeypatch):
+        from get_weather_data.core.config import Config, set_config
+        from get_weather_data.main import Weather
+
+        set_config(
+            Config(ncdc_token="test-token", data_dir=tmp_path, cache_dir=tmp_path)
+        )
+        w = Weather(online=True)
+        with pytest.raises(ValueError, match="requires the local database"):
+            w.get_hourly("11371", "2023-01-01")
+
+
+class TestHourlyFrame:
+    def test_frame_shape(self):
+        pytest.importorskip("pandas")
+        from get_weather_data.weather.frame import hourly_results_to_frame
+
+        r = HourlyResult(
+            observed_at=datetime(2023, 1, 1, 0, tzinfo=UTC),
+            temp=10.0,
+            units="metric",
+        )
+        df = hourly_results_to_frame([r])
+        assert next(iter(df.columns)) == "observed_at"
+        assert "temp" in df.columns
+        assert "wind_direction" in df.columns
+        assert df["temp"].iloc[0] == 10.0
+
+    def test_empty_frame_has_columns(self):
+        pytest.importorskip("pandas")
+        from get_weather_data.weather.frame import hourly_results_to_frame
+
+        df = hourly_results_to_frame([])
+        assert "temp" in df.columns
+        assert len(df) == 0


### PR DESCRIPTION
## Summary

Phase 3 of the niche-win roadmap — **hourly observations**, the package's first sub-daily data. Major version because it adds a new result type and API surface; the daily API is untouched.

- `Weather.get_hourly(location, start, end)` → one `HourlyResult` per hour from NOAA **ISD-Lite** at the nearest USAF-WBAN (airport) station: `temp`, `dewpoint`, `sea_level_pressure`, `wind_direction` (degrees), `wind_speed`, `sky_condition`, `precip_1h`, `precip_6h` — in the configured units. **Timestamps are UTC.**
- `get_hourly_frame(...)` for pandas (one row per hour) and a `get-weather hourly <loc> <date> [--end …] [--units …]` CLI command.
- New public `HourlyResult` type and `weather/isd.py` reader (per-station-year gz cache, reusing the download/freshness/immutable-year pattern from the daily paths).
- Hourly requires the local database (`setup()`); ISD-Lite has no CDO/online equivalent, so `Weather(online=True).get_hourly(...)` raises a clear error.

## Verification

- Full local gate green: ruff, ruff format, pyright (0 errors), pydoclint, `sphinx -W`, `pytest --cov` **241 passed / 89.70%** (floor 85).
- New `tests/test_hourly.py` (16 tests): ISD-Lite field scaling + `-9999` sentinels + date filtering + malformed rows, the download/cache path (respx), nearest-station selection, metric↔imperial conversion, the station-walk fallback, and frame shape.
- Live-audited before codifying: `get_hourly("11371", 2023-07-16)` returns 24 UTC hours at LaGuardia (725030-14732, 942 m), temps 75–81 °F, wind in mph, tz-aware timestamps. A `-m live` E2E asserts a near-complete, time-ordered day with plausible temps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)